### PR TITLE
Fix: Change user message output from stdout to stderr

### DIFF
--- a/src/utils/global-settings.ts
+++ b/src/utils/global-settings.ts
@@ -27,7 +27,7 @@ export class GlobalSettings {
     }
     // Normalize the base directory path
     this._allowedBaseDir = path.resolve(baseDir); 
-    console.log(`[GlobalSettings] Allowed base directory set to: ${this._allowedBaseDir}`);
+    console.error(`[GlobalSettings] Allowed base directory set to: ${this._allowedBaseDir}`);
   }
 
   /**


### PR DESCRIPTION
## Summary
This PR fixes the issue where user messages are incorrectly sent to stdout instead of stderr, which causes JSON parsing failures in the MCP communication protocol.

## Problem
The MCP server uses stdout for JSON-based communication. However, when user messages (like initialization logs) are sent to stdout instead of stderr, they interfere with this protocol, causing parsing errors like:

```
Failed to parse message: "[GlobalSettings] Allowed base directory set to: /path/to/directory\n"
```

## Changes
This PR modifies the global-settings.ts file to redirect user messages from console.log() to console.error(), ensuring they go to stderr instead of stdout:

```typescript
// Before
console.log(`[GlobalSettings] Allowed base directory set to: ${this._allowedBaseDir}`);

// After
console.error(`[GlobalSettings] Allowed base directory set to: ${this._allowedBaseDir}`);
```

## Testing
Tested by verifying messages now appear in stderr and no longer cause JSON parsing errors in the client.